### PR TITLE
fix: stop after esplora error

### DIFF
--- a/src/indexers/esplora.rs
+++ b/src/indexers/esplora.rs
@@ -116,7 +116,10 @@ impl Indexer for BlockingClient {
                 eprint!(".");
                 let mut txids = Vec::new();
                 match self.scripthash_txs(&script, None) {
-                    Err(err) => errors.push(err),
+                    Err(err) => {
+                        errors.push(err);
+                        break;
+                    }
                     Ok(txes) if txes.is_empty() => {
                         empty_count += 1;
                         if empty_count >= BATCH_SIZE as usize {


### PR DESCRIPTION
**Descripton**

The bp-cli goes into an eternal loop when request to esplora server fails, in the synchronization stage.

**Reproduction Steps**


Execute the following command with a invalid esplora server:

```bash
bp create default --tr-key-only '[01f9456f/86h/1h/0h]tpub..../<0;1>/*'  -e whatever
```

