### PR TITLE
Remove esplora from default features.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ toml = { workspace = true, optional = true }
 cfg_eval = { workspace = true, optional = true }
 
 [features]
-default = ["esplora"]
+default = []
 all = ["esplora", "fs"]
 esplora = ["bp-esplora"]
 fs = ["serde"]


### PR DESCRIPTION
Fixes what's breaking this PR in WASM: https://github.com/RGB-WG/rgb/pull/131