### PR TITLE
Refactor CI flow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/cli"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/convert"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,13 +13,14 @@ jobs:
   default:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      # NOTE: Dont use nix here everything should be based on the ubuntu-latest
       - name: Install rust stable
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
-      - name: Default build
+      - name: Latest Ubuntu build check
         uses: actions-rs/cargo@v1
         with:
           command: check
@@ -35,22 +36,12 @@ jobs:
           - fs
           - serde,esplora
     steps:
-      - uses: actions/checkout@v2
-      - name: Install rust stable
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Feature ${{ matrix.feature }}
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --no-default-features --features=${{ matrix.feature }}
-      - name: Defaults + ${{ matrix.feature }}
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --features=${{ matrix.feature }}
+      - uses: actions/checkout@v4
+        uses: cachix/install-nix-action@v26
+      - name: Check feature ${{ matrix.feature }} only
+        run: nix develop .#stable -c cargo check --no-default-features --features=${{ matrix.feature }}
+      - name: Check feature ${{ matrix.feature }} with defaults
+        run: nix develop .#stable -c cargo check --features=${{ matrix.feature }}
   platforms:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -58,7 +49,8 @@ jobs:
       matrix:
         os: [ ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, windows-2019, windows-2022 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      # NOTE: Dont use nix in platform checks everything should based on the host system
       - name: Install rust stable
         uses: actions-rs/toolchain@v1
         with:
@@ -74,16 +66,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [ nightly, beta, stable, 1.70.0 ]
+        toolchain: [ nightly, beta, stable, msrv ]
     steps:
-      - uses: actions/checkout@v2
-      - name: Install rust ${{ matrix.toolchain }}
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          override: true
-      - name: All features
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --workspace --all-targets --all-features
+      - uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v26
+      - name: Check rgb-core
+        run: nix develop ".#${{ matrix.toolchain }}" -c cargo check --workspace --all-targets --all-features

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -13,41 +13,23 @@ jobs:
   codecov:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt, llvm-tools-preview
+      - uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v26
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release
-        env:
-          CARGO_INCREMENTAL: "0"
-          RUSTFLAGS: "-Cinstrument-coverage"
-          RUSTDOCFLAGS: "-Cinstrument-coverage"
+        run: nix develop .#codecov -c cargo build --release
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features --no-fail-fast
-        env:
-          CARGO_INCREMENTAL: "0"
-          RUSTFLAGS: "-Cinstrument-coverage"
-          RUSTDOCFLAGS: "-Cinstrument-coverage"
+        run: nix develop .#codecov -c cargo test --all-features --no-fail-fast
       - name: Install grcov
-        run: if [[ ! -e ~/.cargo/bin/grcov ]]; then cargo install grcov; fi
+        run: nix develop .#codecov -c cargo install grcov
       - name: Generate coverage
-        run: grcov . --binary-path target/debug/deps/ -s . -t lcov --branch --ignore-not-existing --ignore '../**' --ignore '/*' -o coverage.lcov
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        run: nix develop .#codecov -c grcov . --binary-path target/debug/deps/ -s . -t lcov --branch --ignore-not-existing --ignore '../**' --ignore '/*' -o coverage.lcov
+      - name: Upload coverage
+        uses: codecov/codecov-action@v4
         with:
           files: ./coverage.lcov
           flags: rust
-          fail_ci_if_error: true
+          # TODO: set true when CODECOV_TOKEN is set
+          fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,45 +13,24 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Install rustc nightly
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-          components: rustfmt
-      - uses: actions-rs/cargo@v1
-        name: Formatting
-        with:
-          command: fmt
-          args: --all -- --check
+      - uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v26
+      - name: Formatting
+        run: nix develop .#nightly -c cargo fmt --all -- --check
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Install rustc stable
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          components: clippy
-      - uses: actions-rs/cargo@v1
-        name: Clippy
-        with:
-          command: clippy
-          args: --workspace --all-features --all-targets
+      - uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v26
+      - name: Clippy
+        run: nix develop .#stable -c cargo clippy --workspace --all-features --all-targets
   doc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Install rustc nightly
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-          components: rust-docs
-      - uses: actions-rs/cargo@v1
-        name: Doc
-        with:
-          command: doc
-          args: --workspace --all-features
+      - uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v26
+      - name: Doc
+        run: nix develop .#nightly -c cargo doc --workspace --all-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,14 +13,8 @@ jobs:
   testing:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Install latest stable
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+      - uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v26
       - name: Build & test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --all-features --no-fail-fast
+        run: nix develop .#stable -c cargo test --workspace --all-features --no-fail-fast

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["cryptography::cryptocurrencies"]
 authors = ["Dr Maxim Orlovsky <orlovsky@lnp-bp.org>"]
 homepage = "https://lnp-bp.org"
 repository = "https://github.com/BP-WG/bp-wallet"
-rust-version = "1.70" # Due to clap
+rust-version = "1.70.0" # Due to clap
 edition = "2021"
 license = "Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Contribution guidelines can be found in [CONTRIBUTING](CONTRIBUTING.md)
 
 ### MSRV
 
-This library requires minimum rust compiler version (MSRV) 1.60.0.
+Minimum supported rust compiler version (MSRV) is shown in `rust-version` of `Cargo.toml`.
 
 ### Policy on altcoins
 

--- a/convert/Cargo.toml
+++ b/convert/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 authors = ["Dr Maxim Orlovsky <orlovsky@lnp-bp.org>"]
 homepage = "https://lnp-bp.org"
 repository = "https://github.com/BP-WG/bp-wallet"
-rust-version = "1.60" # Due to rust-amplify
+rust-version = "1.60.0" # Due to rust-amplify
 edition = "2021"
 license = "Apache-2.0"
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,85 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1713714899,
+        "narHash": "sha256-+z/XjO3QJs5rLE5UOf015gdVauVRQd2vZtsFkaXBq2Y=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "6143fc5eeb9c4f00163267708e26191d1e918932",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1713924823,
+        "narHash": "sha256-kOeyS3GFwgnKvzuBMmFqEAX0xwZ7Nj4/5tXuvpZ0d4U=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "8a2edac3ae926a2a6ce60f4595dcc4540fc8cad4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,72 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+    };
+
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, rust-overlay, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+
+        commonPackages = with pkgs; [
+            openssl
+            pkg-config
+        ];
+        cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+
+        stableWithLlvm = pkgs.rust-bin.nightly.latest.default.override {
+          extensions = [ "rustfmt" "llvm-tools-preview" ];
+          targets = [ ];
+        };
+      in
+      with pkgs;
+      {
+        devShells = rec {
+          default = msrv;
+
+          msrv = mkShell {
+            buildInputs = commonPackages ++ [
+              rust-bin.stable."${cargoToml.workspace."rust-version"}".default
+            ];
+          };
+
+          stable = mkShell {
+            buildInputs = commonPackages ++ [
+              rust-bin.stable.latest.default
+            ];
+          };
+
+          beta = mkShell {
+            buildInputs = commonPackages ++ [
+              rust-bin.beta.latest.default
+            ];
+          };
+
+          nightly = mkShell {
+            buildInputs = commonPackages ++ [
+              rust-bin.nightly.latest.default
+            ];
+          };
+
+          codecov = mkShell {
+            buildInputs = commonPackages ++ [
+              stableWithLlvm
+            ];
+            CARGO_INCREMENTAL = "0";
+            RUSTFLAGS = "-Cinstrument-coverage";
+            RUSTDOCFLAGS = "-Cinstrument-coverage";
+          };
+        };
+      }
+    );
+}


### PR DESCRIPTION
- CI will use MSRV from Rust manifest (Cargo.toml)
- Reduce usage of actions-rs, which are no longer maintained after Oct 13, 2023.
- Set up dependency upgrade bot
- Refactor lint, test, build with Nix
- Allow codecov upload failure
- `bp-convert` is not included because #23 