### PR TITLE
fix Wallet::update response

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -144,7 +144,7 @@ impl<K, D: Descriptor<K>, L2: Layer2> Runtime<D, K, L2> {
     }
     pub fn set_name(&mut self, name: String) { self.wallet.set_name(name) }
 
-    pub fn sync<I: Indexer>(&mut self, indexer: &I) -> Result<usize, Vec<I::Error>> {
+    pub fn sync<I: Indexer>(&mut self, indexer: &I) -> Result<(), Vec<I::Error>> {
         self.wallet.update(indexer).into_result()
     }
 

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -344,11 +344,12 @@ impl<K, D: Descriptor<K>, L2: Layer2> Wallet<K, D, L2> {
 
     pub fn set_name(&mut self, name: String) { self.data.name = name; }
 
-    pub fn update<B: Indexer>(&mut self, indexer: &B) -> MayError<usize, Vec<B::Error>> {
-        WalletCache::with::<_, K, _, L2>(&self.descr, indexer).map(|cache| self.cache = cache);
+    pub fn update<B: Indexer>(&mut self, indexer: &B) -> MayError<(), Vec<B::Error>> {
+        let result =
+            WalletCache::with::<_, K, _, L2>(&self.descr, indexer).map(|cache| self.cache = cache);
         // Not yet implemented:
         // self.cache.update::<B, K, D, L2>(&self.descr, indexer)
-        MayError::ok(0)
+        result
     }
 
     pub fn to_deriver(&self) -> D


### PR DESCRIPTION
I've mistakenly instantiated an `AnyIndexer::Esplora` with an invalid URL, then I called the `Wallet::update` method which unconditionally returns `MayError::ok(0)` even when the call to `WalletCache::with` fails. With this hardcoded result it was untrivial to find the error because the call to `Wallet::update` was succeeding and the call to `Wallet::address_coins` was not returning any error, just an empty result.

With this PR I've changed the `Wallet::update` method in order to return the result of `WalletCache::with`, so that possible errors (e.g. the invalid URL one) can be catched ASAP. I've also changed the signature of the method because IMO instead of returning a hardcoded value (I assume this was because some feature has not been implemented yet) we should return a unit result and change the signature again once the feature has been implemented. But if you prefer returning the hardcoded value (`0`) in case of success let me know, I'll update this PR to only avoid hiding errors from `WalletCache::with`.