### PR TITLE
fix CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,7 @@ jobs:
       matrix:
         os: [ ubuntu-22.04, ubuntu-latest, macos-13, macos-latest, windows-2019, windows-latest ]
     steps:
+      - uses: ilammy/setup-nasm@v1
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Platform ${{matrix.os}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-13, macos-latest, windows-latest ]
     steps:
+      - uses: ilammy/setup-nasm@v1
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Test ${{matrix.os}}

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -346,8 +346,8 @@ impl<L2: Layer2Cache> CloneNoPersistence for WalletCache<L2> {
         Self {
             persistence: None,
             descriptor: self.descriptor.clone(),
-            last_block: self.last_block.clone(),
-            last_change: self.last_change.clone(),
+            last_block: self.last_block,
+            last_change: self.last_change,
             headers: self.headers.clone(),
             tx: self.tx.clone(),
             utxo: self.utxo.clone(),


### PR DESCRIPTION
This should fix the windows build on the CI by adding nasm as a dependency (it's not needed for mac and linux but I don't know how to selectively add a dependency for specific values of the matrix)
Also linted the code since there were 2 issues that were breaking the CI