### PR TITLE
test round trip

### DIFF
--- a/src/bip43.rs
+++ b/src/bip43.rs
@@ -433,3 +433,30 @@ impl DerivationStandard for Bip43 {
         derivation
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bip43_str_round_trip() {
+        fn assert_from_str_to_str(bip43: Bip43) {
+            let str = bip43.to_string();
+            let from_str = Bip43::from_str(&str).unwrap();
+
+            assert_eq!(bip43, from_str);
+        }
+
+        assert_from_str_to_str(Bip43::Bip44);
+        assert_from_str_to_str(Bip43::Bip84);
+        assert_from_str_to_str(Bip43::Bip49);
+        assert_from_str_to_str(Bip43::Bip86);
+        assert_from_str_to_str(Bip43::Bip45);
+        assert_from_str_to_str(Bip43::Bip48Nested);
+        assert_from_str_to_str(Bip43::Bip48Native);
+        assert_from_str_to_str(Bip43::Bip87);
+        assert_from_str_to_str(Bip43::Bip43 {
+            purpose: HardenedIndex::hardened(1),
+        });
+    }
+}

--- a/src/data.rs
+++ b/src/data.rs
@@ -419,3 +419,35 @@ impl WalletAddr<i64> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_inpoint_str_round_trip() {
+        let s = "cca7507897abc89628f450e8b1e0c6fca4ec3f7b34cccf55f3f531c659ff4d79.1";
+        assert_eq!(Inpoint::from_str(s).unwrap().to_string(), s);
+    }
+
+    #[test]
+    fn test_party_str_round_trip() {
+        fn assert_from_str_to_str(party: Party) {
+            let str = party.to_string();
+            let from_str = Party::from_str(&str).unwrap();
+
+            assert_eq!(party, from_str);
+        }
+
+        assert_from_str_to_str(Party::Subsidy);
+        assert_from_str_to_str(Party::Counterparty(
+            Address::from_str("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq").unwrap(),
+        ));
+        assert_from_str_to_str(Party::Unknown(
+            ScriptPubkey::from_hex("76a91455ae51684c43435da751ac8d2173b2652eb6410588ac").unwrap(),
+        ));
+        assert_from_str_to_str(Party::Wallet(
+            DerivedAddr::from_str("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq&1/1").unwrap(),
+        ));
+    }
+}

--- a/src/rows.rs
+++ b/src/rows.rs
@@ -221,3 +221,26 @@ impl<L2: Layer2Cache> WalletCache<L2> {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_counterparty_str_round_trip() {
+        fn assert_from_str_to_str(counterparty: Counterparty) {
+            let str = counterparty.to_string();
+            let from_str = Counterparty::from_str(&str).unwrap();
+
+            assert_eq!(counterparty, from_str);
+        }
+
+        assert_from_str_to_str(Counterparty::Miner);
+        assert_from_str_to_str(Counterparty::Address(
+            Address::from_str("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq").unwrap(),
+        ));
+        assert_from_str_to_str(Counterparty::Unknown(
+            ScriptPubkey::from_hex("0014a3f8e1f1e1c7e8b4b2f4f3a1b4f7f0a1b4f7f0a1").unwrap(),
+        ));
+    }
+}


### PR DESCRIPTION
This PR adds some simple tests to check that string round-trip conversion of all objects implementing `from_str` works fine.

In addition, I've also formatted the code with `cargo +nightly fmt --all`.