### PR TITLE
Add getters to wallet info L1 data

### DIFF
--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -503,6 +503,8 @@ impl<K, D: Descriptor<K>> Wallet<K, D> {
             layer2: none!(),
         }
     }
+    pub fn data_l1(&self) -> &WalletData<Layer2Empty> { &self.data }
+    pub fn cache_l1(&self) -> &WalletCache<Layer2Empty> { &self.cache }
 }
 
 impl<K, D: Descriptor<K>, L2: Layer2> Wallet<K, D, L2> {


### PR DESCRIPTION
**Description**

This PR adds two new methods to access wallet info from layer 1, similar to those we have in [layer 2](https://github.com/BP-WG/bp-wallet/blob/master/src/wallet.rs#L532-L533). This simplifies the implementation of some modules, such as custom indexers and the asynchronous persistence layer.

In my case, where I was using IndexedDB (browser), adding these methods reduced my code by ~30% and made it more stable, as WASM's main problems are only detectable at runtime.