### PR TITLE
wallet cache provider

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -34,7 +34,7 @@ use crate::cli::{
 };
 use crate::fs::FsTextStore;
 use crate::indexers::esplora;
-use crate::{AnyIndexer, Wallet};
+use crate::{AnyIndexer, Layer2Empty, Wallet, WalletCache};
 
 /// Command-line arguments
 #[derive(Parser)]
@@ -119,14 +119,14 @@ impl<C: Clone + Eq + Debug + Subcommand, O: DescriptorOpts> Args<C, O> {
     pub fn bp_wallet<D: Descriptor>(
         &self,
         conf: &Config,
-    ) -> Result<Wallet<XpubDerivable, D>, ExecError>
+    ) -> Result<Wallet<XpubDerivable, D, WalletCache<Layer2Empty>>, ExecError>
     where
         for<'de> D: From<O::Descr> + serde::Serialize + serde::Deserialize<'de>,
     {
         eprint!("Loading descriptor");
         let sync = self.sync || self.wallet.descriptor_opts.is_some();
 
-        let mut wallet: Wallet<XpubDerivable, D> =
+        let mut wallet: Wallet<XpubDerivable, D, WalletCache<Layer2Empty>> =
             if let Some(d) = self.wallet.descriptor_opts.descriptor() {
                 eprintln!(" from command-line argument");
                 eprint!("Syncing");

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -36,7 +36,10 @@ use strict_encoding::Ident;
 
 use crate::cli::{Args, Config, DescriptorOpts, Exec};
 use crate::fs::FsTextStore;
-use crate::{coinselect, AnyIndexerError, Indexer, OpType, Wallet, WalletAddr, WalletUtxo};
+use crate::{
+    coinselect, AnyIndexerError, Indexer, Layer2Empty, OpType, Wallet, WalletAddr, WalletCache,
+    WalletUtxo,
+};
 
 #[derive(Subcommand, Clone, PartialEq, Eq, Debug, Display)]
 pub enum Command {
@@ -237,14 +240,17 @@ impl<O: DescriptorOpts> Exec for Args<Command, O> {
                         if config.default_wallet == name { "\t[default]\t" } else { "\t\t" }
                     );
                     let provider = FsTextStore::new(entry.path().clone())?;
-                    let wallet = match Wallet::<XpubDerivable, O::Descr>::load(provider, true) {
-                        Err(err) => {
-                            error!("Error loading wallet descriptor: {err}");
-                            println!("# broken wallet descriptor");
-                            continue;
-                        }
-                        Ok(wallet) => wallet,
-                    };
+                    let wallet =
+                        match Wallet::<XpubDerivable, O::Descr, WalletCache<Layer2Empty>>::load(
+                            provider, true,
+                        ) {
+                            Err(err) => {
+                                error!("Error loading wallet descriptor: {err}");
+                                println!("# broken wallet descriptor");
+                                continue;
+                            }
+                            Ok(wallet) => wallet,
+                        };
                     println!("\t{}", wallet.descriptor());
                 }
                 if count == 0 {

--- a/src/data.rs
+++ b/src/data.rs
@@ -32,6 +32,7 @@ use bpstd::{
     ScriptPubkey, SeqNo, SigScript, Terminal, TxVer, Txid, Witness,
 };
 use psbt::{Prevout, Utxo};
+use sha2::{Digest, Sha256};
 
 pub type BlockHeight = NonZeroU32;
 
@@ -222,6 +223,18 @@ impl WalletTx {
         let credit = self.credit_sum().sats_i64();
         let debit = self.debit_sum().sats_i64();
         debit - credit
+    }
+
+    pub fn inputs_sha256(&self) -> Vec<u8> {
+        Sha256::digest(
+            self.inputs
+                .iter()
+                .map(|input| format!("{}:{}", input.outpoint.txid, input.outpoint.vout))
+                .collect::<Vec<_>>()
+                .join("|")
+                .as_bytes(),
+        )
+        .to_vec()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,4 +64,4 @@ pub use layer2::{
 };
 pub use rows::{CoinRow, Counterparty, OpType, TxRow};
 pub use util::MayError;
-pub use wallet::{Wallet, WalletCache, WalletData, WalletDescr};
+pub use wallet::{Wallet, WalletCache, WalletCacheProvider, WalletData, WalletDescr};

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -20,6 +20,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::cmp;
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::marker::PhantomData;
@@ -35,9 +36,9 @@ use nonasync::persistence::{
 use psbt::{Psbt, PsbtConstructor, PsbtMeta, Utxo};
 
 use crate::{
-    BlockInfo, CoinRow, Indexer, Layer2, Layer2Cache, Layer2Data, Layer2Descriptor, Layer2Empty,
-    MayError, MiningInfo, NoLayer2, Party, TxCredit, TxDebit, TxRow, TxStatus, WalletAddr,
-    WalletTx, WalletUtxo,
+    BlockInfo, CoinRow, Counterparty, Indexer, Layer2, Layer2Cache, Layer2Data, Layer2Descriptor,
+    Layer2Empty, MayError, MiningInfo, NoLayer2, OpType, Party, TxCredit, TxDebit, TxRow, TxStatus,
+    WalletAddr, WalletTx, WalletUtxo,
 };
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Display, Error)]
@@ -291,6 +292,203 @@ impl<L2: Layer2Data> Drop for WalletData<L2> {
     }
 }
 
+pub trait WalletCacheProvider<L2C: Layer2Cache>: Persisting {
+    fn layer2(&self) -> &L2C;
+
+    fn layer2_mut(&mut self) -> &mut L2C;
+
+    fn addr_by_address(&self, addr: &Address) -> Option<(Keychain, WalletAddr)>;
+
+    fn addrs(&self) -> impl Iterator<Item = (Keychain, WalletAddr)>;
+
+    fn new_tx(&mut self, txid: Txid, tx: WalletTx);
+
+    fn tx(&self, txid: &Txid) -> Option<Cow<'_, WalletTx>>;
+
+    fn txs(&self) -> impl Iterator<Item = (Txid, Cow<'_, WalletTx>)> + '_;
+
+    fn new_utxo(&mut self, outpoint: Outpoint);
+
+    fn utxo(&self, outpoint: &Outpoint) -> Option<Cow<'_, Outpoint>>;
+
+    fn utxos(&self) -> impl Iterator<Item = Outpoint> + '_;
+
+    fn coins(&self) -> impl Iterator<Item = CoinRow<L2C::Coin>> + '_ {
+        self.utxos().map(|outpoint| {
+            let tx = self.tx(&outpoint.txid).expect("cache data inconsistency");
+            let out = tx.outputs.get(outpoint.vout_usize()).expect("cache data inconsistency");
+            CoinRow {
+                height: tx.status.map(|info| info.height),
+                outpoint,
+                address: out.derived_addr().expect("cache data inconsistency"),
+                amount: out.value,
+                layer2: none!(), // TODO: Add support to WalletTx
+            }
+        })
+    }
+
+    fn history(&self) -> impl Iterator<Item = TxRow<L2C::Tx>> + '_ {
+        self.txs().map(|(_, tx)| {
+            let (credit, debit) = tx.credited_debited();
+            let mut row = TxRow {
+                height: tx.status.map(|info| info.height),
+                operation: OpType::Credit,
+                our_inputs: tx
+                    .inputs
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(idx, inp)| inp.derived_addr().map(|_| idx as u32))
+                    .collect(),
+                counterparties: none!(),
+                own: none!(),
+                txid: tx.txid,
+                fee: tx.fee,
+                weight: tx.weight,
+                size: tx.size,
+                total: tx.total_moved(),
+                amount: Sats::ZERO,
+                balance: Sats::ZERO,
+                layer2: none!(), // TODO: Add support to WalletTx
+            };
+            // TODO: Add balance calculation
+            row.own = tx
+                .inputs
+                .iter()
+                .filter_map(|i| i.derived_addr().map(|a| (a, -i.value.sats_i64())))
+                .chain(
+                    tx.outputs
+                        .iter()
+                        .filter_map(|o| o.derived_addr().map(|a| (a, o.value.sats_i64()))),
+                )
+                .collect();
+            if credit.is_non_zero() {
+                row.counterparties = tx.credits().fold(Vec::new(), |mut cp, inp| {
+                    let party = Counterparty::from(inp.payer.clone());
+                    cp.push((party, inp.value.sats_i64()));
+                    cp
+                });
+                row.counterparties.extend(tx.debits().fold(Vec::new(), |mut cp, out| {
+                    let party = Counterparty::from(out.beneficiary.clone());
+                    cp.push((party, -out.value.sats_i64()));
+                    cp
+                }));
+                row.operation = OpType::Credit;
+                row.amount = credit - debit - tx.fee;
+            } else if debit.is_non_zero() {
+                row.counterparties = tx.debits().fold(Vec::new(), |mut cp, out| {
+                    let party = Counterparty::from(out.beneficiary.clone());
+                    cp.push((party, -out.value.sats_i64()));
+                    cp
+                });
+                row.operation = OpType::Debit;
+                row.amount = debit;
+            }
+            row
+        })
+    }
+
+    fn outpoint_by(&self, outpoint: Outpoint) -> Result<(WalletUtxo, ScriptPubkey), NonWalletItem> {
+        let tx = self.tx(&outpoint.txid).ok_or(NonWalletItem::NonWalletTx(outpoint.txid))?;
+        let debit = tx
+            .outputs
+            .get(outpoint.vout.into_usize())
+            .ok_or(NonWalletItem::NoOutput(outpoint.txid, outpoint.vout))?;
+        let terminal = debit.derived_addr().ok_or(NonWalletItem::NonWalletUtxo(outpoint))?.terminal;
+        if debit.spent.is_some() {
+            debug_assert!(!self.is_unspent(outpoint));
+            return Err(NonWalletItem::Spent(outpoint));
+        }
+        debug_assert!(self.is_unspent(outpoint));
+        let utxo = WalletUtxo {
+            outpoint,
+            value: debit.value,
+            terminal,
+            status: tx.status,
+        };
+        let spk =
+            debit.beneficiary.script_pubkey().ok_or(NonWalletItem::NonWalletUtxo(outpoint))?;
+        Ok((utxo, spk))
+    }
+
+    fn is_unspent(&self, outpoint: Outpoint) -> bool { self.utxo(&outpoint).is_some() }
+
+    fn has_outpoint(&self, outpoint: Outpoint) -> bool {
+        let Some(tx) = self.tx(&outpoint.txid) else {
+            return false;
+        };
+        let Some(out) = tx.outputs.get(outpoint.vout.to_usize()) else {
+            return false;
+        };
+        matches!(out.beneficiary, Party::Wallet(_))
+    }
+
+    fn register_psbt(&mut self, psbt: &Psbt, meta: &PsbtMeta) {
+        let unsigned_tx = psbt.to_unsigned_tx();
+        let txid = unsigned_tx.txid();
+        let wallet_tx = WalletTx {
+            txid,
+            status: TxStatus::Mempool,
+            inputs: psbt
+                .inputs()
+                .map(|input| {
+                    let addr = Address::with(&input.prev_txout().script_pubkey, meta.network).ok();
+                    TxCredit {
+                        outpoint: input.previous_outpoint,
+                        payer: match (self.utxo(&input.previous_outpoint), addr) {
+                            (Some(_), Some(addr)) => {
+                                let (keychain, index) = self
+                                    .addr_by_address(&addr)
+                                    .map(|(keychain, a)| (keychain, a.terminal.index))
+                                    .expect("address cache inconsistency");
+                                Party::Wallet(DerivedAddr::new(addr, keychain, index))
+                            }
+                            (_, Some(addr)) => Party::Counterparty(addr),
+                            _ => Party::Unknown(input.prev_txout().script_pubkey.clone()),
+                        },
+                        sequence: unsigned_tx.inputs[input.index()].sequence,
+                        coinbase: false,
+                        script_sig: none!(),
+                        witness: none!(),
+                        value: input.value(),
+                    }
+                })
+                .collect(),
+            outputs: psbt
+                .outputs()
+                .map(|output| {
+                    let vout = Vout::from_u32(output.index() as u32);
+                    let addr = Address::with(&output.script, meta.network).ok();
+                    TxDebit {
+                        outpoint: Outpoint::new(txid, vout),
+                        beneficiary: match (meta.change, addr) {
+                            (Some(change), Some(addr)) if change.vout == vout => {
+                                Party::Wallet(DerivedAddr::new(
+                                    addr,
+                                    change.terminal.keychain,
+                                    change.terminal.index,
+                                ))
+                            }
+                            (_, Some(addr)) => Party::Counterparty(addr),
+                            (_, _) => Party::Unknown(output.script.clone()),
+                        },
+                        value: output.value(),
+                        spent: None,
+                    }
+                })
+                .collect(),
+            fee: meta.fee,
+            size: meta.size,
+            weight: meta.weight,
+            version: unsigned_tx.version,
+            locktime: unsigned_tx.lock_time,
+        };
+        self.new_tx(txid, wallet_tx);
+        if let Some(change) = meta.change {
+            self.new_utxo(Outpoint::new(txid, change.vout));
+        }
+    }
+}
+
 #[cfg_attr(
     feature = "serde",
     derive(serde::Serialize, serde::Deserialize),
@@ -315,6 +513,38 @@ pub struct WalletCache<L2: Layer2Cache> {
     pub utxo: BTreeSet<Outpoint>,
     pub addr: BTreeMap<Keychain, BTreeSet<WalletAddr>>,
     pub layer2: L2,
+}
+
+impl<L2C> WalletCacheProvider<L2C> for WalletCache<L2C>
+where L2C: Layer2Cache
+{
+    fn layer2(&self) -> &L2C { &self.layer2 }
+
+    fn layer2_mut(&mut self) -> &mut L2C { &mut self.layer2 }
+
+    fn addr_by_address(&self, addr: &Address) -> Option<(Keychain, WalletAddr)> {
+        self.addrs().find(|(_, a)| a.addr == *addr)
+    }
+
+    fn addrs(&self) -> impl Iterator<Item = (Keychain, WalletAddr)> {
+        self.addr.iter().flat_map(|(keychain, addrs)| addrs.iter().map(|addr| (*keychain, *addr)))
+    }
+
+    fn new_tx(&mut self, txid: Txid, tx: WalletTx) { self.tx.insert(txid, tx); }
+
+    fn tx(&self, txid: &Txid) -> Option<Cow<'_, WalletTx>> { self.tx.get(txid).map(Cow::Borrowed) }
+
+    fn txs(&self) -> impl Iterator<Item = (Txid, Cow<'_, WalletTx>)> + '_ {
+        self.tx.iter().map(|(txid, wallet_tx)| (*txid, Cow::Borrowed(wallet_tx)))
+    }
+
+    fn new_utxo(&mut self, outpoint: Outpoint) { self.utxo.insert(outpoint); }
+
+    fn utxo(&self, outpoint: &Outpoint) -> Option<Cow<'_, Outpoint>> {
+        self.utxo.get(outpoint).map(Cow::Borrowed)
+    }
+
+    fn utxos(&self) -> impl Iterator<Item = Outpoint> + '_ { self.utxo.iter().copied() }
 }
 
 impl<L2C: Layer2Cache> WalletCache<L2C> {
@@ -483,25 +713,6 @@ impl<L2C: Layer2Cache> WalletCache<L2C> {
             })
         })
     }
-
-    pub fn utxos(&self) -> impl Iterator<Item = WalletUtxo> + '_ {
-        self.utxo.iter().filter_map(|outpoint| {
-            let tx = self.tx.get(&outpoint.txid).expect("cache data inconsistency");
-            let debit = tx.outputs.get(outpoint.vout_usize()).expect("cache data inconsistency");
-            let terminal =
-                debit.derived_addr().expect("UTXO doesn't belong to the wallet").terminal;
-            if debit.spent.is_some() {
-                None
-            } else {
-                Some(WalletUtxo {
-                    outpoint: *outpoint,
-                    value: debit.value,
-                    terminal,
-                    status: tx.status,
-                })
-            }
-        })
-    }
 }
 
 impl<L2: Layer2Cache> CloneNoPersistence for WalletCache<L2> {
@@ -543,20 +754,29 @@ impl<L2: Layer2Cache> Drop for WalletCache<L2> {
 }
 
 #[derive(Debug)]
-pub struct Wallet<K, D: Descriptor<K>, L2: Layer2 = NoLayer2> {
+pub struct Wallet<K, D: Descriptor<K>, Cache: WalletCacheProvider<L2::Cache>, L2: Layer2 = NoLayer2>
+{
     descr: WalletDescr<K, D, L2::Descr>,
     data: WalletData<L2::Data>,
-    cache: WalletCache<L2::Cache>,
+    cache: Cache,
     layer2: L2,
 }
 
-impl<K, D: Descriptor<K>, L2: Layer2> Deref for Wallet<K, D, L2> {
+impl<K, D: Descriptor<K>, Cache: WalletCacheProvider<L2::Cache>, L2: Layer2> Deref
+    for Wallet<K, D, Cache, L2>
+{
     type Target = WalletDescr<K, D, L2::Descr>;
 
     fn deref(&self) -> &Self::Target { &self.descr }
 }
 
-impl<K, D: Descriptor<K>, L2: Layer2> CloneNoPersistence for Wallet<K, D, L2> {
+impl<
+        K,
+        D: Descriptor<K>,
+        Cache: CloneNoPersistence + WalletCacheProvider<L2::Cache>,
+        L2: Layer2,
+    > CloneNoPersistence for Wallet<K, D, Cache, L2>
+{
     fn clone_no_persistence(&self) -> Self {
         Self {
             descr: self.descr.clone_no_persistence(),
@@ -567,7 +787,9 @@ impl<K, D: Descriptor<K>, L2: Layer2> CloneNoPersistence for Wallet<K, D, L2> {
     }
 }
 
-impl<K, D: Descriptor<K>, L2: Layer2> PsbtConstructor for Wallet<K, D, L2> {
+impl<K, D: Descriptor<K>, Cache: Persisting + WalletCacheProvider<L2::Cache>, L2: Layer2>
+    PsbtConstructor for Wallet<K, D, Cache, L2>
+{
     type Key = K;
     type Descr = D;
 
@@ -597,7 +819,7 @@ impl<K, D: Descriptor<K>, L2: Layer2> PsbtConstructor for Wallet<K, D, L2> {
     }
 }
 
-impl<K, D: Descriptor<K>> Wallet<K, D> {
+impl<K, D: Descriptor<K>> Wallet<K, D, WalletCache<Layer2Empty>> {
     pub fn new_layer1(descr: D, network: Network) -> Self {
         Wallet {
             cache: WalletCache::new_nonsync(),
@@ -608,7 +830,7 @@ impl<K, D: Descriptor<K>> Wallet<K, D> {
     }
 }
 
-impl<K, D: Descriptor<K>, L2: Layer2> Wallet<K, D, L2> {
+impl<K, D: Descriptor<K>, L2: Layer2> Wallet<K, D, WalletCache<L2::Cache>, L2> {
     pub fn new_layer2(descr: D, l2_descr: L2::Descr, layer2: L2, network: Network) -> Self {
         Wallet {
             cache: WalletCache::new_nonsync(),
@@ -618,6 +840,12 @@ impl<K, D: Descriptor<K>, L2: Layer2> Wallet<K, D, L2> {
         }
     }
 
+    pub fn txos(&self) -> impl Iterator<Item = WalletUtxo> + '_ { self.cache.txos() }
+}
+
+impl<K, D: Descriptor<K>, Cache: WalletCacheProvider<L2::Cache>, L2: Layer2>
+    Wallet<K, D, Cache, L2>
+{
     pub fn set_name(&mut self, name: String) {
         self.data.name = name;
         self.data.mark_dirty();
@@ -631,7 +859,7 @@ impl<K, D: Descriptor<K>, L2: Layer2> Wallet<K, D, L2> {
     }
 
     pub fn data_l2(&self) -> &L2::Data { &self.data.layer2 }
-    pub fn cache_l2(&self) -> &L2::Cache { &self.cache.layer2 }
+    pub fn cache_l2(&self) -> &L2::Cache { &self.cache.layer2() }
 
     pub fn with_data<T, E>(
         &mut self,
@@ -655,14 +883,9 @@ impl<K, D: Descriptor<K>, L2: Layer2> Wallet<K, D, L2> {
         &mut self,
         f: impl FnOnce(&mut L2::Cache) -> Result<T, E>,
     ) -> Result<T, E> {
-        let res = f(&mut self.cache.layer2)?;
+        let res = f(&mut self.cache.layer2_mut())?;
         self.cache.mark_dirty();
         Ok(res)
-    }
-
-    #[must_use]
-    pub fn update<I: Indexer>(&mut self, indexer: &I) -> MayError<(), Vec<I::Error>> {
-        self.cache.update::<I, K, D, L2>(&self.descr, indexer).map(|_| ())
     }
 
     pub fn to_deriver(&self) -> D
@@ -703,7 +926,9 @@ impl<K, D: Descriptor<K>, L2: Layer2> Wallet<K, D, L2> {
     pub fn balance(&self) -> Sats { self.cache.coins().map(|utxo| utxo.amount).sum::<Sats>() }
 
     #[inline]
-    pub fn transactions(&self) -> &BTreeMap<Txid, WalletTx> { &self.cache.tx }
+    pub fn transactions(&self) -> impl Iterator<Item = (Txid, Cow<'_, WalletTx>)> + '_ {
+        self.cache.txs()
+    }
 
     #[inline]
     pub fn coins(&self) -> impl Iterator<Item = CoinRow<<L2::Cache as Layer2Cache>::Coin>> + '_ {
@@ -721,7 +946,7 @@ impl<K, D: Descriptor<K>, L2: Layer2> Wallet<K, D, L2> {
     }
 
     pub fn address_balance(&self) -> impl Iterator<Item = WalletAddr> + '_ {
-        self.cache.addr.values().flat_map(|set| set.iter()).copied()
+        self.cache.addrs().map(|(_, addr)| addr)
     }
 
     #[inline]
@@ -739,8 +964,24 @@ impl<K, D: Descriptor<K>, L2: Layer2> Wallet<K, D, L2> {
         self.cache.outpoint_by(outpoint)
     }
 
-    pub fn txos(&self) -> impl Iterator<Item = WalletUtxo> + '_ { self.cache.txos() }
-    pub fn utxos(&self) -> impl Iterator<Item = WalletUtxo> + '_ { self.cache.utxos() }
+    pub fn utxos(&self) -> impl Iterator<Item = WalletUtxo> + '_ {
+        self.cache.utxos().flat_map(|outpoint| {
+            let tx = self.cache.tx(&outpoint.txid).expect("cache data inconsistency");
+            let debit = tx.outputs.get(outpoint.vout_usize()).expect("cache data inconsistency");
+            let terminal =
+                debit.derived_addr().expect("UTXO doesn't belong to the wallet").terminal;
+            if debit.spent.is_some() {
+                None
+            } else {
+                Some(WalletUtxo {
+                    outpoint,
+                    value: debit.value,
+                    terminal,
+                    status: tx.status,
+                })
+            }
+        })
+    }
 
     pub fn coinselect<'a>(
         &'a self,
@@ -762,17 +1003,38 @@ impl<K, D: Descriptor<K>, L2: Layer2> Wallet<K, D, L2> {
     }
 }
 
-impl<K, D: Descriptor<K>, L2: Layer2> Wallet<K, D, L2> {
-    pub fn load<P>(provider: P, autosave: bool) -> Result<Wallet<K, D, L2>, PersistenceError>
-    where P: Clone
+impl<K, D: Descriptor<K>, L2: Layer2> Wallet<K, D, WalletCache<L2::Cache>, L2> {
+    pub fn set_id(&mut self, id: &impl ToString) {
+        self.data.id = Some(id.to_string());
+        self.cache.id = Some(id.to_string());
+    }
+}
+
+impl<K, D: Descriptor<K>, L2: Layer2> Wallet<K, D, WalletCache<L2::Cache>, L2> {
+    #[must_use]
+    pub fn update<I: Indexer>(&mut self, indexer: &I) -> MayError<(), Vec<I::Error>> {
+        indexer.update::<K, D, L2>(&self.descr, &mut self.cache).map(drop)
+    }
+}
+
+impl<K, D: Descriptor<K>, Cache: WalletCacheProvider<L2::Cache> + Persisting, L2: Layer2>
+    Wallet<K, D, Cache, L2>
+{
+    pub fn load<P>(
+        provider: P,
+        autosave: bool,
+    ) -> Result<Wallet<K, D, Cache, L2>, PersistenceError>
+    where
+        P: Clone
             + PersistenceProvider<WalletDescr<K, D, L2::Descr>>
             + PersistenceProvider<WalletData<L2::Data>>
-            + PersistenceProvider<WalletCache<L2::Cache>>
+            + PersistenceProvider<Cache>
             + PersistenceProvider<L2>
-            + 'static {
+            + 'static,
+    {
         let descr = WalletDescr::<K, D, L2::Descr>::load(provider.clone(), autosave)?;
         let data = WalletData::<L2::Data>::load(provider.clone(), autosave)?;
-        let cache = WalletCache::<L2::Cache>::load(provider.clone(), autosave)?;
+        let cache = Cache::load(provider.clone(), autosave)?;
         let layer2 = L2::load(provider, autosave)?;
 
         Ok(Wallet {
@@ -781,11 +1043,6 @@ impl<K, D: Descriptor<K>, L2: Layer2> Wallet<K, D, L2> {
             cache,
             layer2,
         })
-    }
-
-    pub fn set_id(&mut self, id: &impl ToString) {
-        self.data.id = Some(id.to_string());
-        self.cache.id = Some(id.to_string());
     }
 
     pub fn make_persistent<P>(
@@ -797,7 +1054,7 @@ impl<K, D: Descriptor<K>, L2: Layer2> Wallet<K, D, L2> {
         P: Clone
             + PersistenceProvider<WalletDescr<K, D, L2::Descr>>
             + PersistenceProvider<WalletData<L2::Data>>
-            + PersistenceProvider<WalletCache<L2::Cache>>
+            + PersistenceProvider<Cache>
             + PersistenceProvider<L2>
             + 'static,
     {

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -846,6 +846,24 @@ impl<K, D: Descriptor<K>, L2: Layer2> Wallet<K, D, WalletCache<L2::Cache>, L2> {
 impl<K, D: Descriptor<K>, Cache: WalletCacheProvider<L2::Cache>, L2: Layer2>
     Wallet<K, D, Cache, L2>
 {
+    pub fn bind(
+        descr: WalletDescr<K, D, L2::Descr>,
+        data: WalletData<L2::Data>,
+        cache: Cache,
+        layer2: L2,
+    ) -> Self {
+        Self {
+            descr,
+            data,
+            cache,
+            layer2,
+        }
+    }
+
+    pub fn unbind(self) -> (WalletDescr<K, D, L2::Descr>, WalletData<L2::Data>, Cache) {
+        (self.descr, self.data, self.cache)
+    }
+
     pub fn set_name(&mut self, name: String) {
         self.data.name = name;
         self.data.mark_dirty();

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -860,6 +860,7 @@ impl<K, D: Descriptor<K>, Cache: WalletCacheProvider<L2::Cache>, L2: Layer2>
         }
     }
 
+    #[allow(clippy::type_complexity)]
     pub fn unbind(self) -> (WalletDescr<K, D, L2::Descr>, WalletData<L2::Data>, Cache) {
         (self.descr, self.data, self.cache)
     }
@@ -877,7 +878,7 @@ impl<K, D: Descriptor<K>, Cache: WalletCacheProvider<L2::Cache>, L2: Layer2>
     }
 
     pub fn data_l2(&self) -> &L2::Data { &self.data.layer2 }
-    pub fn cache_l2(&self) -> &L2::Cache { &self.cache.layer2() }
+    pub fn cache_l2(&self) -> &L2::Cache { self.cache.layer2() }
 
     pub fn with_data<T, E>(
         &mut self,
@@ -901,7 +902,7 @@ impl<K, D: Descriptor<K>, Cache: WalletCacheProvider<L2::Cache>, L2: Layer2>
         &mut self,
         f: impl FnOnce(&mut L2::Cache) -> Result<T, E>,
     ) -> Result<T, E> {
-        let res = f(&mut self.cache.layer2_mut())?;
+        let res = f(self.cache.layer2_mut())?;
         self.cache.mark_dirty();
         Ok(res)
     }


### PR DESCRIPTION
We have implemented our own wallet cache along with the corresponding synchronization mechanism. Therefore, we need to abstract the wallet cache interface, allowing us to separate the internal data structures from the wallet and, conversely, reconstruct the wallet from those data structures.
